### PR TITLE
typscript number fix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,18 +13,18 @@ const nextConfig = {
     return [
       {
         source: '/api/reporter-selectors/:reporter',
-        destination: '/api/reporter-selectors/:reporter'
+        destination: '/api/reporter-selectors/:reporter',
       },
       {
         source: '/api/current-cycle',
-        destination: '/api/current-cycle'
+        destination: '/api/current-cycle',
       },
       {
         source: '/api/validators',
-        destination: '/api/validators'
-      }
+        destination: '/api/validators',
+      },
     ]
-  }
+  },
 }
 
 module.exports = nextConfig

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -100,8 +100,10 @@ export default function Home() {
     getAllowedStakingAmount()
       .then((amount) => {
         if (amount !== undefined) {
-          const formattedAmount =
-            new Intl.NumberFormat().format(amount) + ' TRB'
+          const numAmount = Number(amount)
+          const formattedAmount = !isNaN(numAmount)
+            ? new Intl.NumberFormat().format(numAmount) + ' TRB'
+            : '0 TRB'
           setStakingAmount(formattedAmount)
         } else {
           setStakingAmount('0 TRB')


### PR DESCRIPTION
The build is failing due to a TypeScript type error in src/pages/index.tsx. The error occurs because we're trying to pass a string value to Intl.NumberFormat().format(), but this method expects a number or bigint as its argument.