### PR TITLE
heroku build fix

### DIFF
--- a/src/rpc/client/index.ts
+++ b/src/rpc/client/index.ts
@@ -6,19 +6,15 @@ export const isBraveBrowser = () => {
 }
 
 export async function validateConnection(rpcAddress: string): Promise<Boolean> {
-  return new Promise((resolve) => {
-    const wsUrl = replaceHTTPtoWebsocket(rpcAddress)
-    const path = wsUrl.endsWith('/') ? 'websocket' : '/websocket'
-    const socket = new StreamingSocket(wsUrl + path, 3000)
-    socket.events.subscribe({
-      error: () => {
-        resolve(false)
-      },
-    })
-
-    socket.connect()
-    socket.connected.then(() => resolve(true)).catch(() => resolve(false))
-  })
+  try {
+    const httpClient = new HttpClient(rpcAddress)
+    const tmClient = await Tendermint37Client.create(httpClient)
+    const status = await tmClient.status()
+    return !!status
+  } catch (error) {
+    console.debug('Connection validation failed:', error)
+    return false
+  }
 }
 
 export async function connectWebsocketClient(

--- a/src/rpc/subscribe/index.ts
+++ b/src/rpc/subscribe/index.ts
@@ -29,12 +29,12 @@ export function subscribeNewBlock(
       if (currentHeight > lastHeight) {
         const block = await tmClient.block(currentHeight)
         if (block) {
-          // Create a NewBlockEvent-like object
+          // Create a NewBlockEvent object matching the structure used in blocks/index.tsx
           const event: NewBlockEvent = {
             header: block.block.header,
-            hash: block.blockId.hash,
-            events: [], // We don't get events from HTTP, but the interface requires this
-            tx: block.block.txs,
+            txs: block.block.txs || [],
+            lastCommit: block.block.lastCommit,
+            evidence: block.block.evidence
           }
           callback(event)
           lastHeight = currentHeight
@@ -84,11 +84,12 @@ export function subscribeTx(
               try {
                 const txResponse = await tmClient.tx({ hash: tx })
                 if (txResponse) {
-                  // Create a TxEvent-like object
+                  // Create a TxEvent object with all required properties
                   const event: TxEvent = {
                     hash: tx,
                     height: currentHeight,
                     result: txResponse.result,
+                    tx: txResponse.tx // Add the tx property from the response
                   }
                   callback(event)
                 }


### PR DESCRIPTION
The build is failing because the replaceHTTPtoWebsocket function is being used in src/rpc/client/index.ts but it's not defined anywhere. Since we're using HTTP clients instead of WebSocket clients, we can remove the WebSocket-related code.